### PR TITLE
added case for platform compatibility

### DIFF
--- a/bin/explain.sh
+++ b/bin/explain.sh
@@ -14,4 +14,12 @@ for i in "$@"; do
 done
 
 # opens url in browser
-open $url
+# use `open` on OS X, `xdg-open` on GNU-Linux (Ubuntu et al.) 
+case $OSTYPE in
+  darwin*)
+    open $url ;;
+  linux-gnu)
+    xdg-open $url ;;
+  *)
+    echo "no can do"
+esac


### PR DESCRIPTION
Calling `open` will only work on OS X. We should be using `xdg-open` on Arch, Ubuntu and other distros. Alternatively, you could just call `firefox $url` or `google-chrome $url`.
